### PR TITLE
Order page now displays all previous order made only by user

### DIFF
--- a/src/components/orders/OrderForm.js
+++ b/src/components/orders/OrderForm.js
@@ -18,6 +18,7 @@ export const OrderForm = () => {
 
     const submitNewOrder = (evt) => {
         evt.preventDefault()
+        const date = new Date
         const newOrder = {
             locationId: parseInt(order.locationId),
             appetizerId: parseInt(order.appetizerId),
@@ -25,7 +26,7 @@ export const OrderForm = () => {
             dessertId: parseInt(order.dessertId),
             drinkId: parseInt(order.drinkId),
             userId: parseInt(localStorage.getItem("pub_user")),
-            dateOrdered: Date.now()
+            dateOrdered: date.toDateString()
 
         }
         if (newOrder.locationId === 0) {

--- a/src/components/orders/Orders.js
+++ b/src/components/orders/Orders.js
@@ -1,5 +1,42 @@
+import React, { useEffect, useState } from "react"
+
+
+
 export const Orders = () => {
+    const [orders, setOrders] = useState([])
+    const user = localStorage.getItem("pub_user")
+
+    
+    useEffect(
+        () => {
+            fetch(`http://localhost:8088/orders?_expand=appetizer&_expand=entree&_expand=dessert&_expand=drink&userId=${user}`)
+            .then(res => res.json())
+            .then((data) => {
+                setOrders(data)
+            })
+        },
+        []
+    )
+    
+    
     return (
+        <>
         <h1>Orders</h1>
+        {
+            orders.map((order) => {
+                
+                 return <div key={`order--${order.id}`}>
+                     <p>Order #{order.id} placed on {order.dateOrdered}:</p>
+                     <ul>
+                         <li>{order.appetizer.name}</li>
+                         <li>{order.entree.name}</li>
+                         <li>{order.dessert.name}</li>
+                         <li>{order.drink.name}</li>
+                     </ul>
+                     <p>Total price: ${order.appetizer.price + order.entree.price + order.dessert.price + order.drink.price}</p>
+                     </div>
+            })    
+        }
+        </>
     )
 }


### PR DESCRIPTION
added:

modified:
`OrderForm.js`
`Order.js`

modifications:
changed the date syntax on `OrderForm.js` to display proper date
added logic to display only the logged in users order history on `Order.js`

steps to test:
1. Log in as a registered user
2. Place at least 2 different orders by going to the menu page and clicking the place order button.
3. Log out and log back in under a different user.
4. Repeat step 2
5. Navigate to the orders page via the navbar link
6. you should see the orders you just placed
7. log out and back in as the first user and repeat step 5
8. you should now see the orders placed for just this user.