### PR TITLE
fixed bug that didnt clear state after you clicked edit button

### DIFF
--- a/src/components/reviews/Reviews.js
+++ b/src/components/reviews/Reviews.js
@@ -84,6 +84,10 @@ export const Reviews = () => {
     }
 
     const editReview = (id) => {
+        const blankForm = {
+            locationId: 0,
+            post: ""
+        }
         const editedReviewObj = {
             locationId: parseInt(review.locationId),
             userId: parseInt(localStorage.getItem("pub_user")),
@@ -109,6 +113,11 @@ export const Reviews = () => {
         .then(() => {
             document.getElementById("reviewForm").reset()
         })
+        .then(() => {
+            setReview(blankForm)
+        })
+
+
 
 
     }}


### PR DESCRIPTION
added:

modified: 
`Reviews.js`

modifications:
added to the PUT fetch call to set the state variable back to an empty object after you click the edit button

steps to test:
1. login as a registered user
2. navigate to the reviews page via the reviews link in the nav bar
3. If you have no reviews, create one.
4. open dev tools and move into you r components tab, watch the reviews component
5. fill out the review form and click edit on one of your posts
6. you should see the object in state#4 get cleared
