### PR TITLE
fixed bug on order form

### DIFF
--- a/src/components/orders/OrderForm.js
+++ b/src/components/orders/OrderForm.js
@@ -127,7 +127,7 @@ export const OrderForm = () => {
                         setOrder(copy)
                     }
                 }>
-                <option value="" >Select a Location</option>
+                <option value={0} >Select a Location</option>
                 {
                     locations.map(location => {
                         return <option key={location.id} value={location.id}>{location.neighborhood}</option>


### PR DESCRIPTION
added:

modified:
`OrderForm.js`

modifications:
changed the value of the location placeholder to 0 so that if someone tries to choose that as an option, a window alert is thrown.

steps to test:
1. Login as a registered user
2. navigate to the order page
3. pick a location , and then fill out the rest of the selections
4. before submit, go back and select Choose a Location in the location dropdown
5. Click submit and you should get a window alert
6. pick a location and click submit and you should be taken to the orders page and see the new order on the bottom of the screen.